### PR TITLE
gcc fixes

### DIFF
--- a/cpp/mayasceneparsing.cpp
+++ b/cpp/mayasceneparsing.cpp
@@ -132,10 +132,10 @@ bool MayaScene::updateScene(MFn::Type updateElement)
 		obj->updateObject();
 		Logging::debug(MString("updateObj ") + objId + ": " + obj->dagPath.fullPathName());
 
-		// this part is only used if motionblur is turned on, else we have no MbElement::None
+		// this part is only used if motionblur is turned on, else we have no MbElement::MotionBlurNone
 		if (!obj->motionBlurred)
 		{
-			if (MayaTo::getWorldPtr()->worldRenderGlobalsPtr->currentMbElement.elementType == MbElement::None)
+			if (MayaTo::getWorldPtr()->worldRenderGlobalsPtr->currentMbElement.elementType == MbElement::MotionBlurNone)
 			{
 				Logging::debug(MString("found non mb element type. Updating non mb objects.") + objId + ": " + obj->dagPath.fullPathName());
 				if (updateElement == MFn::kShape)

--- a/cpp/renderglobals.cpp
+++ b/cpp/renderglobals.cpp
@@ -215,12 +215,12 @@ MString RenderGlobals::getImageOutputFile()
 
 bool RenderGlobals::isDeformStep()
 {
-	return ((this->currentMbElement.elementType == MbElement::Geo) || (this->currentMbElement.elementType == MbElement::Both));
+	return ((this->currentMbElement.elementType == MbElement::MotionBlurGeo) || (this->currentMbElement.elementType == MbElement::MotionBlurBoth));
 }
 
 bool RenderGlobals::isTransformStep()
 {
-	return ((this->currentMbElement.elementType == MbElement::XForm) || (this->currentMbElement.elementType == MbElement::Both));
+	return ((this->currentMbElement.elementType == MbElement::MotionBlurXForm) || (this->currentMbElement.elementType == MbElement::MotionBlurBoth));
 }
 
 // If motionblur is turned on, I need to evaluate the instances/geometry serveral times.
@@ -234,8 +234,8 @@ bool RenderGlobals::getMbSteps()
 	//if(this->currentRenderPass->passType == RenderPass::ShadowMap)
 	//{
 	//	MbElement mbel;
-	//	mbel.elementType = MbElement::Both;
-	//	mbel.time = 0.0;
+	//	mbel.elementType = MbElement::MotionBlurBoth;
+	//	mbel.elementTime = 0.0;
 	//	this->mbElementList.push_back(mbel);
 	//	return true;
 	//}
@@ -245,8 +245,8 @@ bool RenderGlobals::getMbSteps()
 	if( !this->doMb )
 	{
 		MbElement mbel;
-		mbel.elementType = MbElement::Both;
-		mbel.time = 0.0;
+		mbel.elementType = MbElement::MotionBlurBoth;
+		mbel.elementTime = 0.0;
 		this->mbElementList.push_back(mbel);
 		return true;
 	}
@@ -299,8 +299,8 @@ bool RenderGlobals::getMbSteps()
 		for( int step = 0; step < this->xftimesamples; step++)
 		{
 			MbElement mbel;
-			mbel.elementType = MbElement::XForm;
-			mbel.time = mbStepValue;
+			mbel.elementType = MbElement::MotionBlurXForm;
+			mbel.elementTime = mbStepValue;
 			mbStepValue += xfStepSize;
 			sortList.push_back(mbel);
 		}
@@ -313,8 +313,8 @@ bool RenderGlobals::getMbSteps()
 		for( int step = 0; step < this->geotimesamples; step++)
 		{
 			MbElement mbel;
-			mbel.elementType = MbElement::Geo;
-			mbel.time = mbStepValue;
+			mbel.elementType = MbElement::MotionBlurGeo;
+			mbel.elementTime = mbStepValue;
 			mbStepValue += geoStepSize;
 			sortList.push_back(mbel);
 		}
@@ -327,8 +327,8 @@ bool RenderGlobals::getMbSteps()
 
 	// testing this is for non mb objects or changing topology objects
 	MbElement mbel;
-	mbel.elementType = MbElement::None;
-	mbel.time = 0;
+	mbel.elementType = MbElement::MotionBlurNone;
+	mbel.elementTime = 0;
 	this->mbElementList.push_back(mbel);
 
 	return true;

--- a/cpp/renderglobals.h
+++ b/cpp/renderglobals.h
@@ -12,7 +12,7 @@
 
 // A render pass contains a complete render procedure.
 // e.g. a ShadowMap Render pass will start a new rendering. Here all shadow casting lights will produce
-// shadow maps. They can be seen as a pendant to frames in a sequence. 
+// shadow maps. They can be seen as a pendant to frames in a sequence.
 
 // During the render procedure the passes are collected in the render globals.
 // There are preSequence passes. e.g. for shadow maps that are created only once before the final rendering.
@@ -38,14 +38,14 @@ public:
 
 	RenderPassType passType;
 	EvalFrequency evalFrequency;
-	
+
 	std::vector<void *> objectList; // void element pointer to camera, light or other things
 
 	RenderPass()
 	{
 		passType = PassNone;
 		evalFrequency = FrequencyNone;
-	};
+	}
 };
 
 // Some renderers offer different transform mb steps and geometry deformation steps (mantra)
@@ -55,25 +55,25 @@ class MbElement
 public:
 
 	enum Type{
-		XForm,
-		Geo,
-		Both,
-		None
+		MotionBlurXForm,
+		MotionBlurGeo,
+		MotionBlurBoth,
+		MotionBlurNone
 	};
 
 	MbElement::Type elementType;
-	double time;
+	double elementTime;
 
 	// these are for sorting the mb steps
-	bool operator>(const MbElement& other) const 
+	bool operator>(const MbElement& other) const
 	{
-		return ( time > other.time );
-	};
-	bool operator<(const MbElement& other) const 
+		return ( elementTime > other.elementTime );
+	}
+	bool operator<(const MbElement& other) const
 	{
-		return( time < other.time );
-	};
-	MbElement(void){};
+		return( elementTime < other.elementTime );
+	}
+	MbElement(void){}
 };
 
 struct RenderType{
@@ -97,14 +97,14 @@ public:
 	MDistance::Unit rendererUnit;
 	RendererUpAxis internalAxis;
 	RendererUpAxis rendererAxis;
-	
+
 	float internalScaleFactor;
 	float rendererScaleFactor;
 	float toMillimeters(float mm);
 
 	MObject renderGlobalsMobject;
 	bool good;
-	
+
 	bool doAnimation;
 	float currentFrameNumber; // current real frame (with mb steps)
 	float currentFrame; // current frame
@@ -121,12 +121,12 @@ private:
 	int imgHeight;
 	int currentFrameIndex;
 public:
-	void setWidth(int w) { this->imgWidth = w; };
-	void setHeight(int h) { this->imgHeight = h; };
-	void setWidthHeight(int w, int h) { this->imgWidth = w; this->imgHeight = h; };
-	void getWidthHeight(int& w, int& h){ w = this->imgWidth; h = this->imgHeight; };
-	int getWidth(){ return this->imgWidth; };
-	int getHeight(){ return this->imgHeight; };
+	void setWidth(int w) { this->imgWidth = w; }
+	void setHeight(int h) { this->imgHeight = h; }
+	void setWidthHeight(int w, int h) { this->imgWidth = w; this->imgHeight = h; }
+	void getWidthHeight(int& w, int& h){ w = this->imgWidth; h = this->imgHeight; }
+	int getWidth(){ return this->imgWidth; }
+	int getHeight(){ return this->imgHeight; }
 	float updateFrameNumber(); // returns the current frame number and incements the currentFrameIndex
 	float getFrameNumber();
 	bool frameListDone();
@@ -148,14 +148,14 @@ public:
 	float gamma;
 
 	bool doMb;
-	float motionBlurRange; // float range default = 0.4 ~ 144°
+	float motionBlurRange; // float range default = 0.4 ~ 144ï¿½
 	int motionBlurType; // Center, FrameStart, FrameEnd
 	float mbStartTime; // frame relative start time e.g. -0.2 frames
 	float mbEndTime; // frame relative end time e.g. 0.2 frames
 	float mbLength; // absolute length of motion blur, e.g. 0.4 frames
 	bool doDof;
 	int bitdepth; // 8, 16, 16halfFloat, 32float
-	
+
 	int threads;
 	int tilesize;
 	int translatorVerbosity;
@@ -170,7 +170,7 @@ public:
 	std::vector<MbElement> mbElementList;
 	MbElement currentMbElement; // contains type and relative time
 	int currentMbStep; // currend mb step id 0 - x
-	bool isMbStartStep(); 
+	bool isMbStartStep();
 
 	bool createDefaultLight;
 
@@ -195,9 +195,9 @@ private:
 
 public:
 	void checkRenderRegion();
-	void setUseRenderRegion(bool useRegion){ useRenderRegion = useRegion; checkRenderRegion(); };
-	bool getUseRenderRegion() { return useRenderRegion; };
-	void getRenderRegion(int& left, int& bottom, int& right, int& top) { left = regionLeft; bottom = regionBottom; right = regionRight; top = regionTop; };
+	void setUseRenderRegion(bool useRegion){ useRenderRegion = useRegion; checkRenderRegion(); }
+	bool getUseRenderRegion() { return useRenderRegion; }
+	void getRenderRegion(int& left, int& bottom, int& right, int& top) { left = regionLeft; bottom = regionBottom; right = regionRight; top = regionTop; }
 	bool detectShapeDeform;
 	bool exportSceneFile;
 	MString exportSceneFileName;

--- a/cpp/renderprocess.cpp
+++ b/cpp/renderprocess.cpp
@@ -72,13 +72,13 @@ namespace RenderProcess{
 		{
 			MayaTo::getWorldPtr()->worldRenderGlobalsPtr->currentMbStep = mbStepId;
 			MayaTo::getWorldPtr()->worldRenderGlobalsPtr->currentMbElement = MayaTo::getWorldPtr()->worldRenderGlobalsPtr->mbElementList[mbStepId];
-			MayaTo::getWorldPtr()->worldRenderGlobalsPtr->currentFrameNumber = (float)(currentFrame + MayaTo::getWorldPtr()->worldRenderGlobalsPtr->mbElementList[mbStepId].time);
+			MayaTo::getWorldPtr()->worldRenderGlobalsPtr->currentFrameNumber = (float)(currentFrame + MayaTo::getWorldPtr()->worldRenderGlobalsPtr->mbElementList[mbStepId].elementTime);
 			bool needView = true;
 
 			// we can have some mb time steps at the same time, e.g. for xform and deform, then we do not need to update the view
 			if (mbStepId > 0)
 			{
-				if (MayaTo::getWorldPtr()->worldRenderGlobalsPtr->mbElementList[mbStepId].time == MayaTo::getWorldPtr()->worldRenderGlobalsPtr->mbElementList[mbStepId - 1].time)
+				if (MayaTo::getWorldPtr()->worldRenderGlobalsPtr->mbElementList[mbStepId].elementTime == MayaTo::getWorldPtr()->worldRenderGlobalsPtr->mbElementList[mbStepId - 1].elementTime)
 				{
 					needView = false;
 				}

--- a/cpp/utilities/attrtools.cpp
+++ b/cpp/utilities/attrtools.cpp
@@ -137,13 +137,13 @@ MString getString(const char *plugName, MFnDependencyNode& dn)
 	return plug.asString(ctx, &stat);
 }
 
-MString getStringAttr(MString plugName, MFnDependencyNode& dn, MString default)
+MString getStringAttr(MString plugName, MFnDependencyNode& dn, MString defaultValue)
 {
 	MDGContext ctx = MDGContext::fsNormal;
 	MStatus stat = MS::kSuccess;
 	MPlug plug = dn.findPlug(plugName, &stat);
 	if (!stat)
-		return default;
+		return defaultValue;
 	return plug.asString(ctx, &stat);
 }
 
@@ -197,7 +197,7 @@ bool getUInt(const char *plugName, MFnDependencyNode& dn, uint& value)
 	return ret;
 }
 
-bool getBool(MString& plugName, MFnDependencyNode& dn, bool& value)
+bool getBool(const MString& plugName, const MFnDependencyNode& dn, bool& value)
 {
 	MDGContext ctx = MDGContext::fsNormal;
 	MStatus stat = MS::kSuccess;

--- a/cpp/utilities/attrtools.h
+++ b/cpp/utilities/attrtools.h
@@ -38,7 +38,7 @@ bool getString(MString& plugName, MFnDependencyNode& dn, MString& value);
 
 MString getString(const char *plugName, MFnDependencyNode& dn);
 
-MString getStringAttr(MString plugName, MFnDependencyNode& dn, MString default);
+MString getStringAttr(MString plugName, MFnDependencyNode& dn, MString defaultValue);
 
 bool getInt(MString& plugName, MFnDependencyNode& dn, int& value);
 
@@ -48,7 +48,7 @@ int getIntAttr(const char *plugName, MFnDependencyNode& dn, int defaultValue);
 
 bool getUInt(const char *plugName, MFnDependencyNode& dn, uint& value);
 
-bool getBool(MString& plugName, MFnDependencyNode& dn, bool& value);
+bool getBool(const MString& plugName, const MFnDependencyNode& dn, bool& value);
 
 bool getBool(const char *plugName, MFnDependencyNode& dn, bool& value);
 

--- a/cpp/utilities/tools.h
+++ b/cpp/utilities/tools.h
@@ -9,12 +9,15 @@
 #include <maya/MMatrix.h>
 #include <maya/MPlug.h>
 #include <maya/MObjectArray.h>
-#include <direct.h>
-#include <io.h>
 #include <fstream>
 #include <math.h>
 #include <memory>
 #include <vector>
+
+#ifdef _WIN32
+#include <direct.h>
+#include <io.h>
+#endif
 
 static MString RendererName;
 static MString RendererShortCut;


### PR DESCRIPTION
Some gcc / linux fixes:
- Replaced use of None in enum (XWindows headers define a symbol called None (brilliant))
- time clashes with the time function in the C std library
- Do not use C++ keywords as function arguments
- Start removing usage of the evil VC++ extension that allow binding non-const references to temporaries (see here: http://stackoverflow.com/questions/16380966/non-const-reference-bound-to-temporary-visual-studio-bug).
